### PR TITLE
Resolve OpenImmo namespace issues

### DIFF
--- a/OpenImmo/src/main/java/org/openestate/io/openimmo/OpenImmoFeedbackDocument.java
+++ b/OpenImmo/src/main/java/org/openestate/io/openimmo/OpenImmoFeedbackDocument.java
@@ -15,8 +15,6 @@
  */
 package org.openestate.io.openimmo;
 
-import javax.xml.bind.JAXBException;
-import javax.xml.parsers.ParserConfigurationException;
 import org.apache.commons.lang3.StringUtils;
 import org.jaxen.JaxenException;
 import org.openestate.io.core.XmlUtils;
@@ -25,6 +23,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.parsers.ParserConfigurationException;
 
 /**
  * OpenImmo-XML document with a &lt;openimmo_feedback&gt; root element.
@@ -230,6 +231,6 @@ public class OpenImmoFeedbackDocument extends OpenImmoDocument<OpenimmoFeedback>
   public OpenimmoFeedback toObject() throws JAXBException
   {
     this.upgradeToLatestVersion();
-    return (OpenimmoFeedback) OpenImmoUtils.createUnmarshaller().unmarshal( this.getDocument() );
+    return OpenImmoUtils.createUnmarshaller().unmarshal( this.getDocument(), OpenimmoFeedback.class ).getValue();
   }
 }

--- a/OpenImmo/src/main/java/org/openestate/io/openimmo/OpenImmoTransferDocument.java
+++ b/OpenImmo/src/main/java/org/openestate/io/openimmo/OpenImmoTransferDocument.java
@@ -15,8 +15,6 @@
  */
 package org.openestate.io.openimmo;
 
-import javax.xml.bind.JAXBException;
-import javax.xml.parsers.ParserConfigurationException;
 import org.apache.commons.lang3.StringUtils;
 import org.jaxen.JaxenException;
 import org.openestate.io.core.XmlUtils;
@@ -25,6 +23,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.parsers.ParserConfigurationException;
 
 /**
  * OpenImmo-XML document with a &lt;openimmo&gt; root element.
@@ -203,6 +204,6 @@ public class OpenImmoTransferDocument extends OpenImmoDocument<Openimmo>
   public Openimmo toObject() throws JAXBException
   {
     this.upgradeToLatestVersion();
-    return (Openimmo) OpenImmoUtils.createUnmarshaller().unmarshal( this.getDocument() );
+    return OpenImmoUtils.createUnmarshaller().unmarshal( this.getDocument(), Openimmo.class ).getValue();
   }
 }

--- a/OpenImmo/src/main/java/org/openestate/io/openimmo/xml/package-info.java
+++ b/OpenImmo/src/main/java/org/openestate/io/openimmo/xml/package-info.java
@@ -1,0 +1,5 @@
+@XmlSchema(namespace = "http://www.openimmo.de", elementFormDefault = XmlNsForm.UNQUALIFIED)
+package org.openestate.io.openimmo.xml;
+
+import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;


### PR DESCRIPTION
When specifying a namespace in the XML, JAXB couldn't parse it.
You would then have to add a package-info.java for the generated JAXB classes to resolve that issue.
Which leads to another issue of parsing failures without a namespace in the XML.
To solve that, I added the expected type to the unmarshal call.
